### PR TITLE
Need to set bin

### DIFF
--- a/test_check_wildfly_deployments.py
+++ b/test_check_wildfly_deployments.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import check_wildfly as wf
 import requests_mock
 import pytest

--- a/test_check_wildfly_heap_usage.py
+++ b/test_check_wildfly_heap_usage.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import copy
 
 import check_wildfly as wf

--- a/test_check_wildfly_status.py
+++ b/test_check_wildfly_status.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import check_wildfly as wf
 import requests_mock
 import pytest


### PR DESCRIPTION
To prevent getting below errors...

./test_check_wildfly_status.py: line 1: import: command not found
./test_check_wildfly_status.py: line 2: import: command not found
./test_check_wildfly_status.py: line 3: import: command not found
./test_check_wildfly_status.py: line 5: BASE_URL: command not found
./test_check_wildfly_status.py: line 8: syntax error near unexpected token `('
./test_check_wildfly_status.py: line 8: `def before():'